### PR TITLE
Add connection drain duration on envoy preStop step

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: titan-mesh-helm-lib-chart
-version: 1.1.12
+version: 1.1.13
 kubeVersion: '>=1.10.0-0'
 type: library
 description: Titan Service Mesh Helm lib chart for every service

--- a/templates/_containers/_envoy.tpl
+++ b/templates/_containers/_envoy.tpl
@@ -56,7 +56,7 @@
         command:
           - sh
           - -c
-          - wget --post-data="" -O - http://127.0.0.1:10000/healthcheck/fail || true
+          - wget --post-data="" -O - http://127.0.0.1:10000/healthcheck/fail && sleep {{ $envoy.connectionDrainDuration | default "5" }} || true
   livenessProbe:
     httpGet:
       path: {{ $envoyHealthChecksPath }}


### PR DESCRIPTION
envoy API healthcheck/fail is async operation that does not wait for the operation to complete. This adds additional wait period for connections to be drained before initiating SIGTERM