### PR TITLE
Use retryPolicy from remote-app

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: titan-mesh-helm-lib-chart
-version: 1.1.63
+version: 1.1.64
 kubeVersion: '>=1.10.0-0'
 type: library
 description: Titan Service Mesh Helm lib chart for every service

--- a/templates/envoy/_routes.yaml
+++ b/templates/envoy/_routes.yaml
@@ -56,7 +56,7 @@
       {{- end }}
     {{- end }}
     {{- $cluster := ternary (index $clusters $clusterName) .empty (ne $clusterName "") }}
-    {{- $retryPolicy := mergeOverwrite ($cluster.retryPolicy | default dict) ($route.retryPolicy | default dict) }}
+    {{- $retryPolicy := mergeOverwrite ($cluster.retryPolicy | default $remoteMyApp.retryPolicy | default dict) ($route.retryPolicy | default dict) }}
     {{- if or $cluster (or .directResponse .redirect) }}
       {{- if not .match }}
         {{- $retryOn := ternary "reset,connect-failure,refused-stream" "reset,connect-failure,refused-stream,gateway-error" (hasPrefix "local-" $clusterName) }}


### PR DESCRIPTION
remote-app.retryPolicy  will be used as one of the default options to specify retry_policy for clusters