### PR TITLE
Allow to set DNS resolution rate

### DIFF
--- a/templates/envoy/_clusters.yaml
+++ b/templates/envoy/_clusters.yaml
@@ -134,6 +134,9 @@
           {{- $clusterIpAddress := $clusterValue.ip | default $clusterAddress }}
           {{- $clusterType := $clusterValue.type | default "STRICT_DNS" }}
       connect_timeout: {{ $clusterValue.connectionTimeout | default (ternary "0.25s" "1s" (hasPrefix "local-" $cluster)) }}
+      {{- if $clusterValue.dnsRefreshRate }}
+      dns_refresh_rate: {{ $clusterValue.dnsRefreshRate }}
+      {{- end }}
       type: {{ $clusterType }}
       ignore_health_on_host_removal: true
       dns_lookup_family: V4_ONLY


### PR DESCRIPTION
By default DNS resolution in envoy is set 5s. 
In case of 100+ clusters this results in massive amount of DNS requests that overloads the DNS servers.  This change adds ability to modify the resolution rate