### PR TITLE
Support different configurable folder paths for envoy configuration, …

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: titan-mesh-helm-lib-chart
-version: 1.3.5
+version: 1.3.6
 kubeVersion: '>=1.10.0-0'
 type: library
 description: Titan Service Mesh Helm lib chart for every service

--- a/templates/configs/_envoy.yaml
+++ b/templates/configs/_envoy.yaml
@@ -19,6 +19,7 @@
   {{- if or (and $ingress (not $ingress.enabled)) (and $egress (not $egress.enabled)) }}
     {{- $useDynamicConfiguration := $envoy.useDynamicConfiguration | default false }}
     {{- if $useDynamicConfiguration }}
+      {{- $envoyConfigFolder := $envoy.configFolder | default "/envoy/config" }}
 envoy.yaml: |
   node:
     cluster: {{ $appName }}
@@ -26,9 +27,9 @@ envoy.yaml: |
 
   dynamic_resources:
     cds_config:
-      path: /envoy/cds.yaml
+      path: {{ printf "%s/cds.yaml" (trimSuffix "/" $envoyConfigFolder) }}
     lds_config:
-      path: /envoy/lds.yaml
+      path: {{ printf "%s/lds.yaml" (trimSuffix "/" $envoyConfigFolder) }}
 
   admin:
     access_log_path: /dev/stdout

--- a/templates/envoy/_filter_wasm._custom_response.yaml
+++ b/templates/envoy/_filter_wasm._custom_response.yaml
@@ -128,6 +128,7 @@
     {{- $ := set $config "custom_responses" $customResponses }}
   {{- end }}
   {{- if eq (include "titan-mesh-helm-lib-chart.envoy.filter.custom.response.enabled" (dict "requests" $requests "routes" $routes)) "true" }}
+    {{- $envoyFiltersFolder := $envoy.filtersFolder | default "/envoy" }}
 - name: envoy.filters.http.custom_response
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
@@ -165,6 +166,6 @@
         allow_precompiled: {{ $customResponseFilterAllowedPrecompiled }}
         code:
           local:
-            filename: {{ printf "/envoy/%s" $customResponseFilterName | quote }}        
+            filename: {{ printf "%s/%s" (trimSuffix "/" $envoyFiltersFolder) $customResponseFilterName | quote }}        
   {{- end }}
 {{- end }}

--- a/templates/envoy/_filter_wasm.yaml
+++ b/templates/envoy/_filter_wasm.yaml
@@ -148,6 +148,7 @@
     {{- $ := set $enrichment "audits" $audits }}
   {{- end }}
   {{- if eq (include "titan-mesh-helm-lib-chart.envoy.filter.enrichment.enabled" (dict "requests" $requests "routes" $routes)) "true" }}
+    {{- $envoyFiltersFolder := $envoy.filtersFolder | default "/envoy" }}
 - name: envoy.filters.http.enrichment
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
@@ -185,6 +186,6 @@
         allow_precompiled: {{ $enrichfilterAllowedPrecompiled }}
         code:
           local:
-            filename: {{ printf "/envoy/%s" $enrichfilterName | quote }}        
+            filename: {{ printf "%s/%s" (trimSuffix "/" $envoyFiltersFolder) $enrichfilterName | quote }}        
   {{- end }}
 {{- end }}

--- a/templates/envoy/_tls_certs.yaml
+++ b/templates/envoy/_tls_certs.yaml
@@ -1,7 +1,8 @@
 {{- define "titan-mesh-helm-lib-chart.envoy.filter.tls-cert" }}
   {{- $envoy := .envoy -}}
+  {{- $envoyConfigFolder := $envoy.configFolder | default "/envoy/config" -}}
 tls_certificate_sds_secret_configs:
 - name: tls_sds
   sds_config:
-    path: {{ printf "%s/envoy-sds.yaml" ($envoy.configFolder | default "/envoy") }}
+    path: {{ printf "%s/envoy-sds.yaml" (trimSuffix "/" $envoyConfigFolder) }}
 {{- end }}


### PR DESCRIPTION
Support different configurable folder paths for envoy configuration, filters and supported scripts.

- .titanSideCars.envoy.configFolder -> for envoy configuration files, e.g. envoy.yaml, lds.yaml, cds.yaml, default to /envoy/config
- .titanSideCars.envoy.filtersFolder -> for wasm filters binary files, default to /envoy
- .titanSideCars.envoy.scriptsFolder -> for any supported scripts, default to /envoy