### PR TITLE
enable randFromRegex and specify docker platform

### DIFF
--- a/validation-framework/gomplate/functions.tpl
+++ b/validation-framework/gomplate/functions.tpl
@@ -195,7 +195,7 @@
     {{- else if hasKey $match "path" -}}
       {{- $path = printf "%s" $match.path -}}
     {{- else if hasKey $match "regex" -}}
-      {{/* $path = randomRegex $match.regex */}}
+      {{- $path = randFromRegex $match.regex }}
       {{- $supported = false }}
     {{- end -}}
     {{- if $supported }}
@@ -218,7 +218,7 @@
           {{- else if hasKey . "co" -}}
             {{- $val = printf "%s%s%s" (randAscii 5) .co (randAscii 5) -}}              
           {{- else if hasKey . "lk" -}}
-            {{/*- $val = randomRegex .lk -*/}}
+            {{- $val = randFromRegex .lk }}
           {{- else if hasKey . "pr" -}}
             {{- if .pr -}}
               {{- $val = "def" -}}          

--- a/validation-framework/providers/docker-compose-titans.yaml.tpl
+++ b/validation-framework/providers/docker-compose-titans.yaml.tpl
@@ -17,10 +17,11 @@
       {{- $ratelimitEnabled = true -}}
     {{- end -}}
   {{- end -}}
-version: '2'
+version: '3.7'
 services:
   proxy:
     image: {{ $proxy.image }}
+    platform: linux/amd64
     volumes:
       - ./envoy/config:/envoy/config
       - ./envoy/ratelimit:/envoy/ratelimit
@@ -50,6 +51,7 @@ services:
   {{- if $ratelimitEnabled }}
   redis:
     image: {{ $redis.image }}
+    platform: linux/amd64
     restart: always
     expose:
       - "6379"
@@ -61,6 +63,7 @@ services:
 
   ratelimit:
     image: {{ $ratelimit.image }}
+    platform: linux/amd64
     command: /bin/ratelimit
     expose:
       - "8070"
@@ -86,6 +89,7 @@ services:
   {{- end }}
   myapp:
     image: {{ $myapp.image }}
+    platform: linux/amd64
     expose:
      - "8080"
     networks:
@@ -97,6 +101,7 @@ services:
   {{- if $tokenGenerator }}
   token-generator:
     image: {{ $tokenGenerator.image }}
+    platform: linux/amd64
     entrypoint:
     {{- $tokenGenerator.cmds | default (list "/usr/local/broadcom/token-generator/token-generator" "-logFile" "stdout" "-issuer" "http://token-generator" "-useDynamicKey" "true") | toYaml | nindent 6 }}
     expose:
@@ -108,6 +113,7 @@ services:
   {{- end }}
   engine:
     image: {{ $engine.image }}
+    platform: linux/amd64
     entrypoint: 
       - tail 
       - -f


### PR DESCRIPTION
- Enable using randFromRegex to generate random string from regular expression for routing
- Specify dock platform as linux/amd64, so the test could run on arm64 machines