### PR TITLE
Add useSeparateConfigmap option under envoy

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: titan-mesh-helm-lib-chart
-version: 1.3.18
+version: 1.3.19
 kubeVersion: '>=1.10.0-0'
 type: library
 description: Titan Service Mesh Helm lib chart for every service

--- a/templates/_containers/_envoy.tpl
+++ b/templates/_containers/_envoy.tpl
@@ -9,6 +9,7 @@
     {{- $envoyEnabled := eq (include "static.titan-mesh-helm-lib-chart.envoyEnabled" $titanSideCars) "true" -}}
     {{- $envoy := $titanSideCars.envoy -}}
     {{- $useDynamicConfiguration := $envoy.useDynamicConfiguration | default false }}
+    {{- $useSeparateConfigMaps := $envoy.useSeparateConfigMaps | default false }}
     {{- $loadDynamicConfigurationFromGcs := $envoy.loadDynamicConfigurationFromGcs }}
     {{- $loadDynamicConfigurationFromGcsEnabled := ternary $loadDynamicConfigurationFromGcs.enabled false (hasKey $loadDynamicConfigurationFromGcs "enabled") }}
     {{- $envoyConfigFolder := $envoy.configFolder | default "/envoy/config" -}}
@@ -189,12 +190,17 @@
     - mountPath: {{ $envoyConfigVolumeMountPath }}
       name: titan-configs-envoy-data
         {{- else }}
+        {{- if $useSeparateConfigMaps }}
     - mountPath: {{ $envoyConfigFolder }}
       name: titan-configs-envoy-dmc
     - mountPath: {{ printf "%s/cds" (trimSuffix "/" $envoyConfigFolder) }}
       name: titan-configs-envoy-cds
     - mountPath: {{ printf "%s/lds" (trimSuffix "/" $envoyConfigFolder) }}
       name: titan-configs-envoy-lds
+        {{- else }}
+    - mountPath: {{ $envoyConfigFolder }}
+      name: titan-configs-envoy-dmc
+        {{- end }}
         {{- end }}
       {{- else }}
     - mountPath: {{ $envoyConfigFolder }}

--- a/templates/_volumes.tpl
+++ b/templates/_volumes.tpl
@@ -12,6 +12,7 @@
   {{- if $titanSideCars }}
     {{- $envoy := $titanSideCars.envoy -}}
     {{- $useDynamicConfiguration := $envoy.useDynamicConfiguration | default false }}
+    {{- $useSeparateConfigMaps := $envoy.useSeparateConfigMaps | default false }}
     {{- $envoyEnabled := eq (include "static.titan-mesh-helm-lib-chart.envoyEnabled" $titanSideCars) "true" -}}
     {{- $appName := include "titan-mesh-helm-lib-chart.app-name" . -}}
     {{- if $envoyEnabled }}
@@ -38,6 +39,7 @@
       bucketName: {{ $loadDynamicConfigurationFromGcs.bucketName | default "sedicdsaas-dev-stage-envoy" }}
       mountOptions: {{ $loadDynamicConfigurationFromGcs.mountOptions | default (printf "implicit-dirs,only-dir=%s/%s" $namespace $appName) | quote }} 
         {{- else }}
+          {{- if $useSeparateConfigMaps }}
 - name: titan-configs-envoy-dmc
   configMap:
     name: {{ $.Release.Name }}-{{ printf "%s-titan-configs-envoy-dmc" $appName }}
@@ -50,6 +52,12 @@
   configMap:
     name: {{ $.Release.Name }}-{{ printf "%s-titan-configs-envoy-lds" $appName }}
     defaultMode: 420
+          {{- else }}
+- name: titan-configs-envoy-dmc
+  configMap:
+    name: {{ $.Release.Name }}-{{ printf "%s-titan-configs-envoy-dmc" $appName }}
+    defaultMode: 420
+          {{- end }}
         {{- end }}
       {{- else }}
 - name: titan-configs

--- a/templates/configs/_envoy-dmc.yaml
+++ b/templates/configs/_envoy-dmc.yaml
@@ -5,6 +5,7 @@
   {{- $chartName := .chartName }}
   {{- $envoy := $titanSideCars.envoy }}
   {{- $supportPathConfigSource := $envoy.supportPathConfigSource | default false }}
+  {{- $useSeparateConfigMaps := $envoy.useSeparateConfigMaps | default false }}
   {{- $envoyAdminPort := $envoy.adminPort | default "10000"  }}
   {{- $envoyStatsPort := $envoy.statsPort | default "8126"  }}
   {{- $envoyStatsFlushInterval := $envoy.statsFlushInterval | default "30s"  }}
@@ -21,8 +22,8 @@
   {{- $egressEnabled := ternary $egress.enabled true (hasKey $egress "enabled") -}}
   {{- if or $ingressEnabled $egressEnabled }}
     {{- $envoyConfigFolder := $envoy.configFolder | default "/envoy/config" }}
-    {{- $cdsFolder := $envoy.cdsFolderPath | default (printf "%s/cds" (trimSuffix "/" $envoyConfigFolder)) -}}
-    {{- $ldsFolder := $envoy.ldsFolderPath | default (printf "%s/lds" (trimSuffix "/" $envoyConfigFolder)) -}}
+    {{- $cdsFolder := $envoy.cdsFolderPath | default (ternary (printf "%s/cds" (trimSuffix "/" $envoyConfigFolder)) (printf "%s" (trimSuffix "/" $envoyConfigFolder)) $useSeparateConfigMaps) -}}
+    {{- $ldsFolder := $envoy.ldsFolderPath | default (ternary (printf "%s/lds" (trimSuffix "/" $envoyConfigFolder)) (printf "%s" (trimSuffix "/" $envoyConfigFolder)) $useSeparateConfigMaps) -}}
     {{- $loadDynamicConfigurationFromGcs := $envoy.loadDynamicConfigurationFromGcs -}}
     {{- $loadDynamicConfigurationFromGcsEnabled := ternary $loadDynamicConfigurationFromGcs.enabled false (hasKey $loadDynamicConfigurationFromGcs "enabled") -}}
 envoy.yaml: |

--- a/validation-framework/Chart.yaml
+++ b/validation-framework/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   url: https://github.gwd.broadcom.net/SED/titan-mesh-helm-lib-chart
 dependencies:
 - name: titan-mesh-helm-lib-chart
-  version: 1.3.18
+  version: 1.3.19
   repository: https://usw1.packages.broadcom.com/artifactory/sbo-sps-helm-release-local


### PR DESCRIPTION
1. Add a new option to support a single configmap for the dynamic configuration (cds and lds)

- This is needed to avoid envoy hot loading failure due to the update order of cds and lds when there is change dependency from lds to cds, since the order of configmap updating in the projected container is unpredictable and envoy seems having problem of handling out of order updating. 